### PR TITLE
Add rollbar to capture and report exceptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ heroku addons:open sendgrid
 * Go to "Global Settings".
 * Check the "Don't convert plain text emails to HTML" box and "Update".
 
+Rollbar Setup
+-------------
+
+Rollbar provides error tracking, in case anything unexpected happens. Enable
+the addon and optionally set the environment name.
+
+```bash
+heroku addons:add rollbar
+```
+
+Optionally, set the environment name for rollbar. This is probably only
+necessary if you have multiple environment configured to use rollbar.
+
+```bash
+heroku config:set GITHUB_COMMIT_EMAILER_ROLLBAR_ENV=<env_name>
+```
+
 GitHub Setup
 ------------
 
@@ -86,6 +103,7 @@ pip install -r requirements.txt
 GITHUB_COMMIT_EMAILER_SENDER=<email>
 GITHUB_COMMIT_EMAILER_RECIPIENT=<email>
 GITHUB_COMMIT_EMAILER_SECRET=<the_secret>
+ROLLBAR_ACCESS_TOKEN=<rollbar_token>
 SENDGRID_PASSWORD=<sendgrid_password>
 SENDGRID_USERNAME=<sendgrid_user>
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ Flask==0.10.1
 Jinja2==2.7.3
 MarkupSafe==0.23
 Werkzeug==0.9.6
+blinker==1.3
 gunicorn==19.1.1
 itsdangerous==0.24
+rollbar==0.9.6
 wsgiref==0.1.2


### PR DESCRIPTION
Instrument flask app with [rollbar][0] to capture and report exceptions. The
rollbar credentials are taken from the environment using the standard heroku
config vars. The rollbar environment name can be configured using the
`GITHUB_COMMIT_EMAILER_ROLLBAR_ENV` env var.

[0]: http://rollbar.io