### PR TITLE
Support "Approved" header when sending emails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ address.
 heroku config:set GITHUB_COMMIT_EMAILER_REPLY_TO=<reply_to_email>
 ```
 
+Optionally, an "Approved" header value can be configured. The Approved header
+automatically approves the messages for a read-only or moderated mailing list.
+
+```bash
+heroku config:set GITHUB_COMMIT_EMAILER_APPROVED_HEADER=<approved_header>
+```
+
 SendGrid Setup
 --------------
 

--- a/emailer.py
+++ b/emailer.py
@@ -128,6 +128,7 @@ def _send_email(msg_info):
         raise ValueError('sender and recipient config vars must be set.')
 
     reply_to = os.environ.get('GITHUB_COMMIT_EMAILER_REPLY_TO', None)
+    approved = os.environ.get('GITHUB_COMMIT_EMAILER_APPROVED_HEADER', None)
     subject = _get_subject(msg_info['repo'], msg_info['message'])
 
     body = """Branch: {branch}
@@ -154,6 +155,8 @@ Compare: {compare_url}
 
     if reply_to is not None:
         msg.add_header('Reply-To', reply_to)
+    if approved is not None:
+        msg.add_header('Approved', approved)
 
     # Disable SendGrid click tracking.
     send_grid_disable_click_tracking = json.dumps(


### PR DESCRIPTION
"Approved" header value can optionally be set in the config env var,
`GITHUB_COMMIT_EMAILER_APPROVED_HEADER`. The approved header automatically
approves the message for a read-only or moderated mailing list.