### PR TITLE
Support unicode characters in push body from github.

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import envelopes
 import envelopes.connstack
 from flask import Flask
@@ -197,8 +199,16 @@ def _get_subject(repo, message):
 
 def _valid_signature(gh_signature, body, secret):
     """Returns True if GitHub signature is valid. False, otherwise."""
-    if isinstance(gh_signature, unicode):
-        gh_signature = str(gh_signature)
+    def to_str(s):
+        if isinstance(s, unicode):
+            return str(s)
+        else:
+            return s
+
+    gh_signature = to_str(gh_signature)
+    body = to_str(body)
+    secret = to_str(secret)
+
     expected_hmac = hmac.new(secret, body, sha)
-    expected_signature = 'sha1=' + expected_hmac.hexdigest()
+    expected_signature = to_str('sha1=' + expected_hmac.hexdigest())
     return hmac.compare_digest(expected_signature, gh_signature)

--- a/test_emailer.py
+++ b/test_emailer.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import hmac
 import json
 import mock
@@ -261,6 +263,19 @@ class EmailerTests(unittest.TestCase):
         actual_msg = mock_send.return_value.send.call_args[0][0]
         self.check_msg(actual_msg)
         self.assertEqual(None, actual_msg.headers.get('Approved'))
+
+    @mock.patch('envelopes.connstack.get_current_connection')
+    def test_send_email__unicode_body(self, mock_send):
+        """Verify unicode characters in msg_info are handled."""
+        msg_info = self.msg_info
+        msg_info['message'] += '\n\u2026'
+
+        self.prep_env()
+        emailer._send_email(msg_info)
+
+        mock_send.return_value.send.assert_called_once_with(mock.ANY)
+        actual_msg = mock_send.return_value.send.call_args[0][0]
+        self.check_msg(actual_msg)
 
     def test_get_sender__from_author(self):
         """Verify sent from author when appropriate config var set."""


### PR DESCRIPTION
Use unicode literals and decode to ascii when needed.

This fixes a UnicodeEncodeError that was thrown when commit message (or
anything, really) included non-ascii characters.