### PR TITLE
Split on commas in CC environment variable for chapel_commits emails

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -129,7 +129,7 @@ def _send_email(msg_info):
         logging.error('sender and recipient config vars must be set.')
         raise ValueError('sender and recipient config vars must be set.')
 
-    recipient_ccs = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None) 
+    recipient_ccs = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None)
     recipient_cc = recipient_ccs.split(",")
     reply_to = os.environ.get('GITHUB_COMMIT_EMAILER_REPLY_TO', None)
     approved = os.environ.get('GITHUB_COMMIT_EMAILER_APPROVED_HEADER', None)

--- a/emailer.py
+++ b/emailer.py
@@ -130,7 +130,10 @@ def _send_email(msg_info):
         raise ValueError('sender and recipient config vars must be set.')
 
     recipient_ccs = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None)
-    recipient_cc = recipient_ccs.split(",")
+    if recipient_ccs is not None:
+        recipient_cc = recipient_ccs.split(",")
+    else:
+        recipient_cc = None
     reply_to = os.environ.get('GITHUB_COMMIT_EMAILER_REPLY_TO', None)
     approved = os.environ.get('GITHUB_COMMIT_EMAILER_APPROVED_HEADER', None)
     subject = _get_subject(msg_info['repo'], msg_info['message'])

--- a/emailer.py
+++ b/emailer.py
@@ -129,7 +129,8 @@ def _send_email(msg_info):
         logging.error('sender and recipient config vars must be set.')
         raise ValueError('sender and recipient config vars must be set.')
 
-    recipient_cc = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None).split(",")
+    recipient_ccs = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None) 
+    recipient_cc = recipient_ccs.split(",")
     reply_to = os.environ.get('GITHUB_COMMIT_EMAILER_REPLY_TO', None)
     approved = os.environ.get('GITHUB_COMMIT_EMAILER_APPROVED_HEADER', None)
     subject = _get_subject(msg_info['repo'], msg_info['message'])

--- a/emailer.py
+++ b/emailer.py
@@ -129,7 +129,7 @@ def _send_email(msg_info):
         logging.error('sender and recipient config vars must be set.')
         raise ValueError('sender and recipient config vars must be set.')
 
-    recipient_cc = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None)
+    recipient_cc = os.environ.get('GITHUB_COMMIT_EMAILER_RECIPIENT_CC', None).split(",")
     reply_to = os.environ.get('GITHUB_COMMIT_EMAILER_REPLY_TO', None)
     approved = os.environ.get('GITHUB_COMMIT_EMAILER_APPROVED_HEADER', None)
     subject = _get_subject(msg_info['repo'], msg_info['message'])


### PR DESCRIPTION
We're currently observing that a comma-separated list of email
addresses in the GITHUB_COMMIT_EMAILER_RECIPIENT_CC environment
variable is only sending to the first address rather than all of them,
in spite of the fact that the message header looks as though it
contains all of them using a reasonable format.

This applies a .split(",") to the variable before passing it to the
envelopes initializer to see whether splitting it into a list of
addresses works better.