### PR TITLE
Change the separator used for chapel-commits from hyphens to n-dashes

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -143,11 +143,11 @@ Revision: {revision}
 Author: {pusher}
 
 Log Message:
-------------
+––––––––––––
 {message}
 
 Modified Files:
----------------
+–––––––––––––––
 {changed_files}
 
 Compare: {compare_url}


### PR DESCRIPTION
It seems that separators formed by any combination of:

```
-_,=+~#*ᐧ—
```

are stripped when mailed in to a Discourse mailing list.  n-dashes somehow make it through, though, so let's use them.