### PR TITLE
Add encoding comment required by Python 2.7

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import envelopes


### PR DESCRIPTION
(which is used by our correctness-test-github-email-notifications job
apparently)