### PR TITLE
Remove any attempt at dashed separators in chapel-commits mails, for now

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -141,13 +141,11 @@ def _send_email(msg_info):
     body = """Branch: {branch}
 Revision: {revision}
 Author: {pusher}
-
 Log Message:
-––––––––––––
+
 {message}
 
 Modified Files:
-–––––––––––––––
 {changed_files}
 
 Compare: {compare_url}


### PR DESCRIPTION
My attempt to change from '----' to '––––' in our separators ran
afoul of some Python 2 vs. Python 3 issues due to its use of
unicode, and wrestling with it is taking more time than I think
it's worth for now, so this PR stops trying to create visual
separators to try and get commit mails working with Discourse.