### PR TITLE
Change subject for merge messages to support filtering

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -199,7 +199,7 @@ def _get_subject(repo, message):
     else:
         subject_msg = message_lines[0]
     subject_msg = subject_msg[:50]
-    subject = '[Chapel Merge] {1}'.format(repo, subject_msg)
+    subject = '[Chapel Merge] {0}'.format(subject_msg)
     return subject
 
 

--- a/emailer.py
+++ b/emailer.py
@@ -199,7 +199,7 @@ def _get_subject(repo, message):
     else:
         subject_msg = message_lines[0]
     subject_msg = subject_msg[:50]
-    subject = '[{0}] {1}'.format(repo, subject_msg)
+    subject = '[Chapel Merge] {1}'.format(repo, subject_msg)
     return subject
 
 


### PR DESCRIPTION
With the change of commit mails going to Discourse, it was requested
that we use a subject line prefix that's easy to filter on.  This is
the prefix that seemed to represent a consensus-ish on our internal
chat.  Other ideas were to have the first word change based on the
repo (e.g., [Mason Merge], etc.) and/or to have the PR number show up
in the subject line (e.g., [Chapel PR #1234]).  Those were more than I
have time to take on here and now.