### PR TITLE
Fix for E501 errors thrown by flake8 library update

### DIFF
--- a/test_emailer.py
+++ b/test_emailer.py
@@ -342,8 +342,8 @@ class EmailerTests(unittest.TestCase):
         self.assertTrue(emailer._valid_signature(gh_sig, body, secret))
 
     def test_valid_signature__true__unicode(self):
-        """Verify _valid_signature returns true when signature matches, even if github\
-        signature is unicode."""
+        """Verify _valid_signature returns true when signature matches,\
+        even if github signature is unicode."""
         body = '{"rock": "on"}'
         secret = str(uuid.uuid4())
         h = hmac.new(secret.encode('utf8'), body.encode('utf8'),


### PR DESCRIPTION
The library is catching even comment line length.   The lowest impact
change was to fix the comment to change the line length.

Signed-off-by: Tim Zinsky <tim.zinsky@hpe.com>